### PR TITLE
Queuefix, refactoring, new connect API and a small test

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -168,7 +168,7 @@ class PostDispatchThread(threading.Thread):
                     logger.warning("Connection to aw-server established")
                 except req.RequestException as e:
                     # If unable to connect, retry in 10s
-                    time.sleep(10)
+                    time.sleep(40)
             self._load_queue()
             while self.connected and self.running:
                 request = self.queue.get()

--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -14,15 +14,17 @@ from . import config
 
 # FIXME: This line is probably badly placed
 logging.getLogger("requests").setLevel(logging.WARNING)
+logger = logging.getLogger("aw.client")
 
 
 # TODO: Should probably use OAuth or something
 
 class ActivityWatchClient:
     def __init__(self, client_name: str, testing=False):
-        self.logger = logging.getLogger("aw.client")
         self.testing = testing
 
+        self.connected = False
+        self.buckets = []
         self.session = {}
 
         self.client_name = client_name + ("-testing" if testing else "")
@@ -33,31 +35,16 @@ class ActivityWatchClient:
 
         # Setup failed queues dir
         self.data_dir = appdirs.user_data_dir("aw-client")
-        self.failed_queues_dir = os.path.join(self.data_dir, "failed_events", self.client_name)
+        self.failed_queues_dir = os.path.join(self.data_dir, "failed_events")
         if not os.path.exists(self.failed_queues_dir):
             os.makedirs(self.failed_queues_dir)
+        self.queue_file = os.path.join(self.failed_queues_dir, self.client_name)
 
-        # Send old failed events
-        self._post_failed_events()
-        QueueTimerThread(self).start()
+        self.reconnect_thread = ReconnectThread(self)
 
-    def _queue_failed_event(self, bucket: str, data: dict):
-        # Find failed queue file
-        queue_file = os.path.join(self.failed_queues_dir, bucket)
-        with open(queue_file, "a+") as queue_fp:
-            queue_fp.write(json.dumps(data) + "\n")
-
-    def _post_failed_events(self):
-        failed_events = []
-        for bucket in os.listdir(self.failed_queues_dir):
-            queue_file_path = os.path.join(self.failed_queues_dir, bucket)
-            with open(queue_file_path, "r") as queue_fp:
-                for event in queue_fp:
-                    failed_events.append(Event(**json.loads(event)))
-                if len(failed_events) != 0:
-                    self.logger.info("Sent failed events: {}".format(failed_events))
-                    open(queue_file_path, "w").close()  # Clear file
-                    self.send_events(bucket, failed_events)
+    #
+    #   Get/Post base requests
+    #
 
     def _post(self, endpoint: str, data: dict) -> Optional[req.Response]:
         headers = {"Content-type": "application/json"}
@@ -72,72 +59,150 @@ class ActivityWatchClient:
         response.raise_for_status()
         return response
 
-    def send_event(self, bucket, event: Event):
-        endpoint = "buckets/{}/events".format(bucket)
-        data = event.to_json_dict()
-        try:
-            self._post(endpoint, data)
-            self.logger.debug("Sent event to server: {}".format(event))
-        except req.RequestException as e:
-            self.logger.warning("Failed to send event to server ({})".format(e))
-            self._queue_failed_event(bucket, data)
-
-    def send_events(self, bucket, events: List[Event]):
-        endpoint = "buckets/{}/events".format(bucket)
-        data = [event.to_json_dict() for event in events]
-        try:
-            self._post(endpoint, data)
-            self.logger.debug("Sent events to server: {}".format(events))
-        except req.RequestException as e:
-            self.logger.warning("Failed to send events to server ({})".format(e))
-            for event in data:
-                self._queue_failed_event(bucket, event)
-
-    def replace_last_event(self, bucket, event: Event):
-        endpoint = "buckets/{}/events/replace_last".format(bucket)
-        data = event.to_json_dict()
-        try:
-            self._post(endpoint, data)
-            self.logger.debug("Sent event to server: {}".format(event))
-        except req.RequestException as e:
-            self.logger.warning("Failed to send event to server ({})".format(e))
-            self._queue_failed_event(bucket, data)
-
-    def get_buckets(self):
-        return self._get('buckets').json()
+    #
+    #   Event get/post requests
+    #
 
     def get_events(self, bucket) -> List[Event]:
         endpoint = "buckets/{}/events".format(bucket)
         events = self._get(endpoint).json()
         return [Event(**event) for event in events]
 
-    def create_bucket(self, bucket_id, event_type: str) -> bool:
-        # Check if bucket exists
-        buckets = self.get_buckets()
-        if bucket_id in buckets:
-            return False  # Don't do anything if bucket already exists
-        else:
-            # Create bucket
-            endpoint = "buckets/{}".format(bucket_id)
-            data = {
-                'client': self.client_name,
-                'hostname': self.client_hostname,
-                'type': event_type,
-            }
+    def send_event(self, bucket, event: Event):
+        endpoint = "buckets/{}/events".format(bucket)
+        data = event.to_json_dict()
+        if self.connected:
             try:
                 self._post(endpoint, data)
+                logger.debug("Sent event to server: {}".format(event))
             except req.RequestException as e:
-                self.logger.error("Unable to create bucket: {}".format(e))
+                self._connection_lost()
+                logger.warning("Failed to send event to server ({})".format(e))
+                self._queue_failed_request(endpoint, data)
+        else:
+            self._queue_failed_request(endpoint, data)
+
+    def send_events(self, bucket, events: List[Event], ignore_failed=False):
+        endpoint = "buckets/{}/events".format(bucket)
+        data = [event.to_json_dict() for event in events]
+        if self.connected:
+            try:
+                self._post(endpoint, data)
+                logger.debug("Sent events to server: {}".format(events))
+            except req.RequestException as e:
+                self._connection_lost()
+                logger.warning("Failed to send events to server ({})".format(e))
+                for event in data:
+                    self._queue_failed_request(endpoint, event)
+        else:
+            self._queue_failed_request(endpoint, data)
+
+    def replace_last_event(self, bucket, event: Event):
+        endpoint = "buckets/{}/events/replace_last".format(bucket)
+        data = event.to_json_dict()
+        if self.connected:
+            try:
+                self._post(endpoint, data)
+                logger.debug("Sent event to server: {}".format(event))
+            except req.RequestException as e:
+                self._connection_lost()
+                logger.warning("Failed to send event to server ({})".format(e))
+                self._queue_failed_request(endpoint, data)
+        else:
+            self._queue_failed_request(endpoint, data)
+
+    #
+    #   Bucket get/post requests
+    #
+
+    def get_buckets(self):
+        return self._get('buckets').json()
+
+    def setup_bucket(self, bucket_id, event_type: str) -> bool:
+        self.buckets.append({"bid": bucket_id, "etype": event_type})
+        if self.connected:
+            self._create_buckets()
+
+    def _create_buckets(self):
+        # Check if bucket exists
+        buckets = self.get_buckets()
+        for bucket in self.buckets:
+            if bucket['bid'] in buckets:
+                return False  # Don't do anything if bucket already exists
+            else:
+                # Create bucket
+                endpoint = "buckets/{}".format(bucket['bid'])
+                data = {
+                    'client': self.client_name,
+                    'hostname': self.client_hostname,
+                    'type': bucket['etype'],
+                }
+                try:
+                    self._post(endpoint, data)
+                except req.RequestException as e:
+                    logger.error("Failed to create bucket: {}".format(e))
+                return True
+
+    #
+    #   Failed request queue handling
+    #
+
+    def _queue_failed_request(self, endpoint: str, data: dict):
+        # Find failed queue file
+        entry = {"endpoint": endpoint, "data": data}
+        with open(self.queue_file, "a+") as queue_fp:
+            queue_fp.write(json.dumps(entry) + "\n")
+
+    def _post_failed_requests(self):
+        failed_requests = []
+        for bucket in os.listdir(self.failed_queues_dir):
+            with open(self.queue_file, "r") as queue_fp:
+                for request in queue_fp:
+                    failed_requests.append(json.loads(request))
+                if len(failed_requests) != 0:
+                    open(self.queue_file, "w").close()  # Clear file
+                    logger.info("Sending {} failed events: {}".format(len(failed_requests), failed_requests))
+                    for request in failed_requests:
+                        self._post(request['endpoint'], request['data'])
+
+    #
+    #   Connection methods
+    #
+
+    def connect(self):
+        if self._try_connect():
+            self.connected = True
+        else:
+            logger.warning("Can't connect to aw-server, will queue events until connection is available")
+            if not self.reconnect_thread.is_alive():
+                self.reconnect_thread.start()
+
+    def _try_connect(self):
+        try:
+            self._create_buckets()
+            self._post_failed_requests()
             return True
+        except req.RequestException as e:
+            return False
+
+    def _connection_lost(self):
+        """
+            Call this when we lose connection to the server
+        """
+        self.connected = False
+        if not self.reconnect_thread.is_alive():
+            self.reconnect_thread.start()
 
 
-class QueueTimerThread(threading.Thread):
+class ReconnectThread(threading.Thread):
     def __init__(self, client):
         threading.Thread.__init__(self)
         self.daemon = True
         self.client = client
 
     def run(self):
-        while True:
-            time.sleep(180)
-            self.client._post_failed_events()
+        while not self.client.connected:
+            if self.client._try_connect():
+                logger.warning("Connection to aw-server established again")
+            else:
+                time.sleep(60)

--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -10,6 +10,7 @@ from typing import Optional, List, Union
 import requests as req
 
 from aw_core.models import Event
+from aw_core.dirs import get_data_dir
 from . import config
 
 # FIXME: This line is probably badly placed
@@ -34,7 +35,7 @@ class ActivityWatchClient:
         self.server_port = config["server_port"] if not testing else config["testserver_port"]
 
         # Setup failed queues dir
-        self.data_dir = appdirs.user_data_dir("aw-client")
+        self.data_dir = get_data_dir("aw-client")
         self.failed_queues_dir = os.path.join(self.data_dir, "failed_events")
         if not os.path.exists(self.failed_queues_dir):
             os.makedirs(self.failed_queues_dir)

--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -145,7 +145,6 @@ class PostDispatchThread(threading.Thread):
             queue_fp.write(json.dumps(entry) + "\n")
 
     def _load_queue(self):
-        print("Loading queue")
         # If crash when lost connection, queue failed requests
         failed_requests = []
         with open(self.client.queue_file, "r") as queue_fp:
@@ -153,12 +152,11 @@ class PostDispatchThread(threading.Thread):
                 failed_requests.append(json.loads(request))
         open(self.client.queue_file, "w").close()  # Clear file
         if len(failed_requests) > 0:
-            logger.info("Queuing {} failed events: {}".format(len(failed_requests), failed_requests))
+            logger.info("Adding {} failed events to queue to send: {}".format(len(failed_requests), failed_requests))
             for request in failed_requests:
                 self.queue.put([request['endpoint'], request['data']])
 
     def _save_queue(self):
-        print("Saving queue")
         open(self.client.queue_file, "w").close()  # Clear file
         for request in self.queue.queue:
             self.client._queue_failed_request(*request)

--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -174,9 +174,7 @@ class ActivityWatchClient:
     #
 
     def connect(self):
-        if self._try_connect():
-            self.connected = True
-        else:
+        if not self._try_connect():
             logger.warning("Can't connect to aw-server, will queue events until connection is available")
             if self.reconnect_thread == None:
                 self.reconnect_thread = ReconnectThread(self).start()
@@ -185,6 +183,7 @@ class ActivityWatchClient:
         try:
             self._create_buckets()
             self._post_failed_requests()
+            self.connected = True
             return True
         except req.RequestException as e:
             return False
@@ -208,7 +207,6 @@ class ReconnectThread(threading.Thread):
     def run(self):
         while not self.client.connected:
             if self.client._try_connect():
-                self.client.connected = True
                 logger.warning("Connection to aw-server established again")
             else:
                 time.sleep(60)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import time
 
 from random import random
 from datetime import datetime, timedelta, timezone
@@ -9,11 +10,7 @@ from aw_client import ActivityWatchClient
 def create_unique_event():
     return Event(label=str(random()), timestamp=datetime.now(timezone.utc), duration=timedelta())
 
-# Disconnected
-input("Do not start aw-server yet, press enter to continue")
-
 client = ActivityWatchClient("aw-test-client", testing=True)
-client.connect()
 
 bucket_name = "test-bucket"
 bucket_etype = "test"
@@ -21,36 +18,23 @@ client.setup_bucket(bucket_name, bucket_etype)
 
 e1 = create_unique_event()
 e2 = create_unique_event()
+e3 = create_unique_event()
 client.send_event(bucket_name, e1)
 client.replace_last_event(bucket_name, e2)
-
-assert client.connected == False
-
-
-# Connected
-input("Start aw-server and press enter")
-
-e3 = create_unique_event()
 client.replace_last_event(bucket_name, e3)
 
-print("Getting events prior to connect")
-events = client.get_events(bucket_name)
-print("Asserting events prior to connect")
-assert e1 not in events
-assert e2 not in events
-assert e3 not in events
-
 client.connect()
+time.sleep(1)
 
-print("Getting events after connect")
+print("Getting events")
 events = client.get_events(bucket_name)
 
-print("Asserting events after connect")
+print("Asserting events")
 assert events[0]['label'] == e3['label']
 
+print("Getting bucket")
 buckets = client.get_buckets()
-assert client.connected == True
-
+print("Asserting bucket")
 assert bucket_name in buckets
 assert bucket_name == buckets[bucket_name]['id']
 assert bucket_etype == buckets[bucket_name]['type']

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from random import random
+from datetime import datetime, timedelta, timezone
+
+from aw_core.models import Event
+from aw_client import ActivityWatchClient
+
+def create_unique_event():
+    return Event(label=str(random()), timestamp=datetime.now(timezone.utc), duration=timedelta())
+
+# Disconnected
+input("Do not start aw-server yet, press enter to continue")
+
+client = ActivityWatchClient("aw-test-client", testing=True)
+client.connect()
+
+bucket_name = "test-bucket"
+bucket_etype = "test"
+client.setup_bucket(bucket_name, bucket_etype)
+
+e1 = create_unique_event()
+e2 = create_unique_event()
+client.send_event(bucket_name, e1)
+client.replace_last_event(bucket_name, e2)
+
+assert client.connected == False
+
+
+# Connected
+input("Start aw-server and press enter")
+
+e3 = create_unique_event()
+client.replace_last_event(bucket_name, e3)
+
+print("Getting events prior to connect")
+events = client.get_events(bucket_name)
+print("Asserting events prior to connect")
+assert e1 not in events
+assert e2 not in events
+assert e3 not in events
+
+client.connect()
+
+print("Getting events after connect")
+events = client.get_events(bucket_name)
+
+print("Asserting events after connect")
+assert events[0]['label'] == e3['label']
+
+buckets = client.get_buckets()
+assert client.connected == True
+
+assert bucket_name in buckets
+assert bucket_name == buckets[bucket_name]['id']
+assert bucket_etype == buckets[bucket_name]['type']

--- a/tests/test_failqueue.py
+++ b/tests/test_failqueue.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import time
+
+from random import random
+from datetime import datetime, timedelta, timezone
+
+from aw_core.models import Event
+from aw_client import ActivityWatchClient
+
+def create_unique_event():
+    return Event(label=str(random()), timestamp=datetime.now(timezone.utc), duration=timedelta())
+
+bucket_name = "test-bucket"
+bucket_etype = "test"
+
+input("Make sure aw-server isn't running, then press enter > ")
+client1 = ActivityWatchClient("aw-test-client", testing=True)
+client1.setup_bucket(bucket_name, bucket_etype)
+
+print("Creating events")
+e1 = create_unique_event()
+e2 = create_unique_event()
+e3 = create_unique_event()
+client1.send_event(bucket_name, e1)
+client1.replace_last_event(bucket_name, e2)
+client1.replace_last_event(bucket_name, e3)
+
+print("Trying to send events (should fail)")
+client1.connect()
+time.sleep(1)
+client1.disconnect()
+
+input("Start aw-server, then press enter > ")
+
+client2 = ActivityWatchClient("aw-test-client", testing=True)
+client2.setup_bucket(bucket_name, bucket_etype)
+client2.connect()
+time.sleep(1)
+
+
+print("Getting events")
+events = client2.get_events(bucket_name)
+
+print("Asserting latest event")
+#print(events)
+#print(events[0]['label'])
+#print(e3['label'])
+assert events[0]['label'] == e3['label']


### PR DESCRIPTION
When merging this, also merge the updated watchers

https://github.com/ActivityWatch/aw-watcher-window/pull/4
https://github.com/ActivityWatch/aw-watcher-afk/pull/9

**TODO before merge:**
- [x] Fix race condition when _queue_failed_request tries to acquire the lock when _post_failed_requests has it
- [x] Find a way to properly handle if server shuts down when _post_failed_requests and a exception is raised
- [x] 40s reconnect timer
- [x] Non-blocking API
- [x] Reliable failed_requests queue
- [ ] Make DispatchThread internally non-blocking

**NOTE:** After this update feel free to remove your ~/.local/share/aw-client folder because it will no loonger be used.