### PR TITLE
Fix usage of ActivityWatchClient in with-statement

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -178,6 +178,7 @@ class ActivityWatchClient:
 
     def __enter__(self):
         self.connect()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.disconnect()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,3 +42,6 @@ print("Asserting bucket")
 assert bucket_name in buckets
 assert bucket_name == buckets[bucket_name]['id']
 assert bucket_etype == buckets[bucket_name]['type']
+
+with ActivityWatchClient("yet-another-client", testing=True) as client:
+    assert client.name == "yet-another-client"


### PR DESCRIPTION
Add missing `return self` to `__enter__`.