### PR TITLE
Improve heartbeat pre-merging

### DIFF
--- a/aw_client/config.py
+++ b/aw_client/config.py
@@ -14,10 +14,10 @@ default_client_config["server-testing"] = {
 }
 
 default_client_config["client"] = {
-    "commit_interval": "30",
+    "commit_interval": "10",
 }
 default_client_config["client-testing"] = {
-    "commit_interval": "10"
+    "commit_interval": "5"
 }
 
 


### PR DESCRIPTION
30s pre-merging time is way too long, if the client crashes/exists we lose all that data.

This is very important for aw-watcher-vim since it's a watcher that will often be opened/closed very quickly and many files are often not even open for 30s. Since this is a excessive example however I made the default 10s and made it possible to override in the heartbeat function and use 3s in aw-watcher-vim.