### PR TITLE
changed default hostname to 127.0.0.1 (from localhost)

### DIFF
--- a/aw_client/config.py
+++ b/aw_client/config.py
@@ -4,11 +4,11 @@ import aw_core.config
 
 default_client_config = ConfigParser()
 default_client_config["server"] = {
-    "hostname": "localhost",
+    "hostname": "127.0.0.1",
     "port": "5600",
 }
 default_client_config["server-testing"] = {
-    "hostname": "localhost",
+    "hostname": "127.0.0.1",
     "port": "5666"
 }
 


### PR DESCRIPTION
Should be a better default as it removes the need for DNS.

Note that this will have no effect for existing installs (a known issue as we talked about in the aw-server-rust config PR: https://github.com/ActivityWatch/aw-server-rust/pull/21).