### PR TITLE
Change default API limit from 100 to return all events

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -109,7 +109,7 @@ class ActivityWatchClient:
     #   Event get/post requests
     #
 
-    def get_events(self, bucket_id: str, limit: int=100, start: datetime=None, end: datetime=None) -> List[Event]:
+    def get_events(self, bucket_id: str, limit: int=-1, start: datetime=None, end: datetime=None) -> List[Event]:
         endpoint = "buckets/{}/events".format(bucket_id)
 
         params = dict()  # type: Dict[str, str]
@@ -141,7 +141,7 @@ class ActivityWatchClient:
         data = [event.to_json_dict() for event in events]
         self._post(endpoint, data)
 
-    def get_eventcount(self, bucket_id: str, limit: int=100, start: datetime=None, end: datetime=None) -> int:
+    def get_eventcount(self, bucket_id: str, limit: int=-1, start: datetime=None, end: datetime=None) -> int:
         endpoint = "buckets/{}/events/count".format(bucket_id)
 
         params = dict()  # type: Dict[str, str]


### PR DESCRIPTION
In the effort to match my PR for aw-server [#60](https://github.com/ActivityWatch/aw-server/pull/60) and resolve issue [#232](https://github.com/ActivityWatch/activitywatch/issues/232), this request is targeted for aw-client to continue with the default behavior of API to return all results unless a limit is specified.




