### PR TITLE
fix: calculate the duration for single-shot events

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -234,6 +234,12 @@ class ActivityWatchClient:
                 else:
                     self.last_heartbeat[bucket_id] = merge
             else:
+                # If the duration is calculated in `heartbeat_merge`,
+                # an event that occurs only once will have a default duration
+                # of 0. We need to calculate the actual duration before sending
+                # the request.
+                if (last_heartbeat.duration).total_seconds() == 0:
+                    last_heartbeat.duration = event.timestamp - last_heartbeat.timestamp
                 data = last_heartbeat.to_json_dict()
                 self.request_queue.add_request(endpoint, data)
                 self.last_heartbeat[bucket_id] = event


### PR DESCRIPTION
I found several 0s-duration events when I use aw-watcher-window. (I have configured the `poll_time` of aw-watcher-window to 30 seconds, which may help present the issue.)

After some investigation, the reason seems to be the calculation of event duration. The calculation of the event duration is in the `heartbeat_merge` function. However, if an event occurs once and cannot be merged to the next event, the event will have a default duration of 0s, causing the above problem.

This MR detects such a situation and calculate the duration before sending such an event.
