### PR TITLE
api: Make insert_event not return anything anymore

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -159,10 +159,10 @@ class ActivityWatchClient:
     def send_events(self, bucket_id: str, events: List[Event]):
         return self.insert_events(bucket_id, events)
 
-    def insert_event(self, bucket_id: str, event: Event) -> Event:
+    def insert_event(self, bucket_id: str, event: Event) -> None:
         endpoint = "buckets/{}/events".format(bucket_id)
         data = [event.to_json_dict()]
-        return Event(**self._post(endpoint, data).json())
+        self._post(endpoint, data)
 
     def insert_events(self, bucket_id: str, events: List[Event]) -> None:
         endpoint = "buckets/{}/events".format(bucket_id)


### PR DESCRIPTION
This feature has not been used since our very old replace_last code before heartbeats were a thing.

Depends on https://github.com/ActivityWatch/aw-server/pull/76