### PR TITLE
fix(examples): fixed redact_sensitive.py

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -165,6 +165,14 @@ class ActivityWatchClient:
         data = [event.to_json_dict() for event in events]
         self._post(endpoint, data)
 
+    def delete_event(self, bucket_id: str, event: Event) -> None:
+        if event.id == None:
+            raise ValueError(
+                "Cannot delete an event: event ID is undefined."
+            )
+        endpoint = "buckets/{}/events/{}".format(bucket_id, event.id)
+        self._delete(endpoint)
+
     def get_eventcount(
         self,
         bucket_id: str,

--- a/examples/redact_sensitive.py
+++ b/examples/redact_sensitive.py
@@ -67,7 +67,7 @@ def main():
     if bid_to_redact == "*":
         for bucket_id in buckets.keys():
             if bucket_id.startswith("aw-watcher-afk"):
-                return
+                continue
             _redact_bucket(bucket_id, pattern)
     else:
         _redact_bucket(bid_to_redact, pattern)
@@ -97,6 +97,7 @@ def _redact_bucket(bucket_id: str, pattern: Union[str, Pattern]):
                 if DRYRUN:
                     print("DRYRUN, would do: aw.insert_event(bucket_id, e)")
                 else:
+                    aw.delete_event(bucket_id, e_before)
                     aw.insert_event(bucket_id, e)
                     print("Redacted event")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -81,5 +81,18 @@ def test_full():
                 timeperiods=[(now - timedelta(hours=1), datetime.now())],
             )
 
+        # Create and delete an event: check that it no longer exists
+        e_del = create_unique_event()
+        client.insert_event(bucket_name, e_del)
+        fetched_events = client.get_events(bucket_name)
+        assert (e_del.timestamp, e_del.duration, e_del.data) in [
+                (e.timestamp, e.duration, e.data) for e in fetched_events]
+
+        e_del_fetched = [e for e in fetched_events if e.data == e_del.data][0]
+        client.delete_event(bucket_name, e_del_fetched)
+        fetched_events = client.get_events(bucket_name)
+        assert (e_del.timestamp, e_del.duration, e_del.data) not in [
+                (e.timestamp, e.duration, e.data) for e in fetched_events]
+
         # Delete bucket
         client.delete_bucket(bucket_name)


### PR DESCRIPTION
This PR is a fix for `redact_sensitive.py`, which is a program to search and delete events by its name.

The script has two problems:

1. Redacted events are left intact and visible, because only insertion of events with the name "REDACTED" is performed.
2. The program prematurely exits, leaving some buckets not queried.

This PR fixes the 1st issue by creating a Python API for `DELETE` requests (in `client.py`), and calling it from `redact_sensitive.py`. I also implemented a unit test for the relevant function.

Fixing the second issue is trivial, and is addressed at L67 of `redact_sensitive.py`.