### PR TITLE
Allow one to specify server endpoint in config

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -88,9 +88,10 @@ class ActivityWatchClient:
 
         server_host = host or server_config["hostname"]
         server_port = port or server_config["port"]
-        self.server_address = "{protocol}://{host}:{port}".format(
+        default_server_address = "{protocol}://{host}:{port}".format(
             protocol=protocol, host=server_host, port=server_port
         )
+        self.server_address = server_config["endpoint"] or default_server_address
 
         self.instance = SingleInstance(
             f"{self.client_name}-at-{server_host}-on-{server_port}"


### PR DESCRIPTION
I'm experimenting running aw-server-rust from my home k8s network, with a tls enabled ingress. However, when I trying point my local aw-client to the server I find no success - the config doesn't seem to allow me to specify an https endpoint address. Peeking into the code seems to indicate that the endpoint is hard-coded by stitching up a default protocol, and the host, port from config.

I guess there is no reason that it cannot support https, so I patched the source code like this. Now it worked perfectly for me. Would you like to accept it to the upstream?