### PR TITLE
chore: Export intended public imports

### DIFF
--- a/aw_client/__init__.py
+++ b/aw_client/__init__.py
@@ -1,1 +1,3 @@
-from .client import ActivityWatchClient  # noqa
+from .client import ActivityWatchClient
+
+__all__ = ("ActivityWatchClient",)


### PR DESCRIPTION
It looks like MyPy and Pyright currently require imports like these to be re-exported in order to be used. Doing this raises a lint error for me due to Pyright:

```python
import aw_client

aw_client.ActivityWatchClient()  # "ActivityWatchClient" is not exported from module "aw_client"
```

Ref: https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface
Ref: https://github.com/microsoft/pyright/issues/3409
Ref: https://github.com/python/mypy/issues/8754#issuecomment-891109179

---------

I assume the `noqa` was to handle the `ActivityWatchClient` symbol not being used. My linter doesn't complain about it being unused anymore because it special cases for the `__all__` elements even though they are strings. I'm guessing you're linter is the same way but it not you'll probably want to remove that edit. 