### PR TITLE
fix: replace single quotes with double quotes.

### DIFF
--- a/aw_client/queries.py
+++ b/aw_client/queries.py
@@ -137,7 +137,7 @@ def canonicalEvents(params: Union[DesktopQueryParams, AndroidQueryParams]) -> st
             # Categorize
             f"events = categorize(events, {classes_str});" if params.classes else "",
             # Filter out selected categories
-            f"events = filter_keyvals(events, '$category', {cat_filter_str});"
+            f"events = filter_keyvals(events, \"$category\", {cat_filter_str});"
             if params.filter_classes
             else "",
         ]


### PR DESCRIPTION
This fixes #70.  The single quotes was throwing an exception by the lexer on aw-server-rust. 