### PR TITLE
add alternative firefox name

### DIFF
--- a/aw_client/queries.py
+++ b/aw_client/queries.py
@@ -211,6 +211,7 @@ browser_appnames = {
         "Firefox-esr",
         "Firefox Beta",
         "Nightly",
+        "org.mozilla.firefox",
     ],
     "opera": ["opera.exe", "Opera"],
     "brave": ["brave.exe"],


### PR DESCRIPTION
this is how `awatcher` matches it 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c563a9920311c7f42c97872bf5383ef75b1492bd  | 
|--------|--------|

### Summary:
Added `"org.mozilla.firefox"` to `browser_appnames` in `aw_client/queries.py` to ensure correct event processing for this Firefox identifier.

**Key points**:
- Added `"org.mozilla.firefox"` to the `firefox` entry in the `browser_appnames` dictionary in `aw_client/queries.py`.
- Ensures `awatcher` correctly matches and processes events from Firefox identified as `org.mozilla.firefox`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->