### PR TITLE
Fix queries.py Line 119-123

### DIFF
--- a/aw_client/queries.py
+++ b/aw_client/queries.py
@@ -116,9 +116,11 @@ def canonicalEvents(params: Union[DesktopQueryParams, AndroidQueryParams]) -> st
             else "",
             # Fetch browser events
             (
-                browserEvents(params)
-                if isDesktopParams(params)
-                else ""
+                (
+                    browserEvents(params)
+                    if isDesktopParams(params)
+                    else ""
+                )
                 + (  # Include focused and audible browser events as indications of not-afk
                     """
             audible_events = filter_keyvals(browser_events, "audible", [true]);


### PR DESCRIPTION
Fix a simple Operator precedence bug.
```
browserEvents(params)
if isDesktopParams(params)
else ""
+ (...)
```
In this code, `""+(...)` will be interpreted as a whole. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix operator precedence issue in `canonicalEvents()` in `queries.py` by adding parentheses for correct string concatenation.
> 
>   - **Bug Fix**:
>     - Fix operator precedence issue in `canonicalEvents()` in `queries.py`.
>     - Add parentheses around `browserEvents(params) if isDesktopParams(params) else ""` to ensure correct string concatenation order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-client&utm_source=github&utm_medium=referral)<sup> for 3c7aa33aca69e3c0fcb3fb909f72dfea25696413. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->