### PR TITLE
feat: added client.wait_for_start()

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -372,6 +372,20 @@ class ActivityWatchClient:
         # Throw away old thread object, create new one since same thread cannot be started twice
         self.request_queue = RequestQueue(self)
 
+    def wait_for_start(self, timeout: int = 10) -> None:
+        """Wait for the server to start by trying to get the server info."""
+        start_time = datetime.now()
+        sleep_time = 0.1
+        while (datetime.now() - start_time).seconds < timeout:
+            try:
+                self.get_info()
+                break
+            except req.exceptions.ConnectionError:
+                sleep(sleep_time)
+                sleep_time *= 2
+        else:
+            raise Exception("Server did not start in time")
+
 
 QueuedRequest = namedtuple("QueuedRequest", ["endpoint", "data"])
 Bucket = namedtuple("Bucket", ["id", "type"])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `wait_for_start` method to `ActivityWatchClient` to wait for server start with timeout handling.
> 
>   - **New Method**:
>     - Adds `wait_for_start(timeout: int = 10)` to `ActivityWatchClient` in `client.py`.
>     - Attempts to retrieve server info repeatedly until successful or timeout.
>     - Raises exception if server does not start within the timeout period.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-client&utm_source=github&utm_medium=referral)<sup> for ade23b52dbd8e8e6c3e7f7958c254b3022e0cfbd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->