### PR TITLE
feat(client): return created events from insert_event(s)

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -177,15 +177,21 @@ class ActivityWatchClient:
         events = self._get(endpoint, params=params).json()
         return [Event(**event) for event in events]
 
-    def insert_event(self, bucket_id: str, event: Event) -> None:
+    def insert_event(self, bucket_id: str, event: Event) -> Optional[Event]:
         endpoint = f"buckets/{bucket_id}/events"
         data = [event.to_json_dict()]
-        self._post(endpoint, data)
+        response = self._post(endpoint, data)
+        if response.json():
+            return Event(**response.json()[0])
+        return None
 
-    def insert_events(self, bucket_id: str, events: List[Event]) -> None:
+    def insert_events(self, bucket_id: str, events: List[Event]) -> Optional[List[Event]]:
         endpoint = f"buckets/{bucket_id}/events"
         data = [event.to_json_dict() for event in events]
-        self._post(endpoint, data)
+        response = self._post(endpoint, data)
+        if response.json():
+            return [Event(**e) for e in response.json()]
+        return None
 
     def delete_event(self, bucket_id: str, event_id: int) -> None:
         endpoint = f"buckets/{bucket_id}/events/{event_id}"

--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -185,7 +185,9 @@ class ActivityWatchClient:
             return Event(**response.json()[0])
         return None
 
-    def insert_events(self, bucket_id: str, events: List[Event]) -> Optional[List[Event]]:
+    def insert_events(
+        self, bucket_id: str, events: List[Event]
+    ) -> Optional[List[Event]]:
         endpoint = f"buckets/{bucket_id}/events"
         data = [event.to_json_dict() for event in events]
         response = self._post(endpoint, data)


### PR DESCRIPTION
## Summary
- `insert_event()` now returns `Optional[Event]` (was `None`)
- `insert_events()` now returns `Optional[List[Event]]` (was `None`)
- The server already returns created events with assigned IDs in the response body, but the client was discarding them

This is backward-compatible — callers that ignore the return value still work fine. The main use case is getting server-assigned event IDs for later update/delete operations.

Fixes #77.

## Test plan
- [ ] Verify existing tests pass
- [ ] Test that returned events have server-assigned IDs
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `insert_event` and `insert_events` in `aw_client/client.py` now return created events, allowing retrieval of server-assigned IDs.
> 
>   - **Behavior**:
>     - `insert_event()` now returns `Optional[Event]` instead of `None`.
>     - `insert_events()` now returns `Optional[List[Event]]` instead of `None`.
>     - Allows retrieval of server-assigned event IDs for further operations.
>   - **Compatibility**:
>     - Backward-compatible with existing code that ignores return values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-client&utm_source=github&utm_medium=referral)<sup> for 0513857445d149f344a66bd83fcf6ed40c070e77. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->