### PR TITLE
feat(client): return created Event(s) from insert_event/insert_events

### DIFF
--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -177,15 +177,19 @@ class ActivityWatchClient:
         events = self._get(endpoint, params=params).json()
         return [Event(**event) for event in events]
 
-    def insert_event(self, bucket_id: str, event: Event) -> None:
+    def insert_event(self, bucket_id: str, event: Event) -> Event:
         endpoint = f"buckets/{bucket_id}/events"
         data = [event.to_json_dict()]
-        self._post(endpoint, data)
+        response = self._post(endpoint, data)
+        created = response.json()
+        return Event(**created[0]) if created else event
 
-    def insert_events(self, bucket_id: str, events: List[Event]) -> None:
+    def insert_events(self, bucket_id: str, events: List[Event]) -> List[Event]:
         endpoint = f"buckets/{bucket_id}/events"
         data = [event.to_json_dict() for event in events]
-        self._post(endpoint, data)
+        response = self._post(endpoint, data)
+        created = response.json()
+        return [Event(**e) for e in created]
 
     def delete_event(self, bucket_id: str, event_id: int) -> None:
         endpoint = f"buckets/{bucket_id}/events/{event_id}"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,7 +52,11 @@ def test_full():
         e2 = create_unique_event()
         e3 = create_unique_event()
         events = [e1, e2, e3]
-        client.insert_events(bucket_name, events)
+        inserted_events = client.insert_events(bucket_name, events)
+
+        # Check that insert_events returns events with server-assigned IDs
+        assert len(inserted_events) == len(events)
+        assert all(e.id is not None for e in inserted_events)
 
         # Get events
         fetched_events = client.get_events(bucket_name, limit=len(events))
@@ -90,15 +94,18 @@ def test_full():
             )
 
         # Create and delete an event: check that it no longer exists
+        # Also verify that insert_event returns the event with a server-assigned ID
         e_del = create_unique_event()
-        client.insert_event(bucket_name, e_del)
+        e_del_inserted = client.insert_event(bucket_name, e_del)
+        assert e_del_inserted.id is not None
+
         fetched_events = client.get_events(bucket_name)
         assert (e_del.timestamp, e_del.duration, e_del.data) in [
             (e.timestamp, e.duration, e.data) for e in fetched_events
         ]
 
-        e_del_fetched = [e for e in fetched_events if e.data == e_del.data][0]
-        client.delete_event(bucket_name, e_del_fetched)
+        # Use the ID returned from insert_event directly (no need to search for it)
+        client.delete_event(bucket_name, e_del_inserted.id)
         fetched_events = client.get_events(bucket_name)
         assert (e_del.timestamp, e_del.duration, e_del.data) not in [
             (e.timestamp, e.duration, e.data) for e in fetched_events


### PR DESCRIPTION
## Summary

The server already returns the created event(s) with server-assigned IDs in the response body for both the `POST /buckets/{id}/events` endpoint, but the Python client was discarding this data by returning `None`.

This PR changes `insert_event` and `insert_events` to return the created event(s) with their server-assigned IDs:

- `insert_event(bucket_id, event) -> Event` — returns the created event with ID
- `insert_events(bucket_id, events) -> List[Event]` — returns the list of created events with IDs

**Backward compatible**: callers that ignore the return value continue to work unchanged.

## Motivation

The main use case (raised in #77) is getting the server-assigned event ID immediately after insertion, so you can directly use it in `delete_event()` or `get_event()` without a separate lookup.

Before:
```python
client.insert_event(bucket_id, event)
# Have to fetch all events and find it by content to get the ID
fetched = client.get_events(bucket_id)
e = [e for e in fetched if e.data == event.data][0]
client.delete_event(bucket_id, e.id)
```

After:
```python
inserted = client.insert_event(bucket_id, event)
client.delete_event(bucket_id, inserted.id)  # Clean!
```

## Changes

- `aw_client/client.py`: Updated `insert_event` and `insert_events` to capture and return the response
- `tests/test_client.py`: Updated tests to verify returned events have server-assigned IDs; simplified event deletion to use the ID directly from `insert_event`

Closes #77