### PR TITLE
fix: use n parameter in print_top and remove unused limit in get_eventcount

### DIFF
--- a/aw_client/cli.py
+++ b/aw_client/cli.py
@@ -218,12 +218,12 @@ def _parse_events(events: List[dict]) -> List[Event]:
 
 
 def print_top(events: List[Event], key=lambda e: e.data, title="Events", n=10):
-    print(f"Top {n} {title}" + (f" (out of {len(events)})" if len(events) > 10 else ""))
+    print(f"Top {n} {title}" + (f" (out of {len(events)})" if len(events) > n else ""))
     print(
         tabulate(
             [
                 (event.duration, key(event))
-                for event in sorted(events, key=lambda e: e.duration, reverse=True)[:10]
+                for event in sorted(events, key=lambda e: e.duration, reverse=True)[:n]
             ],
             headers=["Duration", "Key"],
         )

--- a/aw_client/client.py
+++ b/aw_client/client.py
@@ -203,7 +203,6 @@ class ActivityWatchClient:
     def get_eventcount(
         self,
         bucket_id: str,
-        limit: int = -1,
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
     ) -> int:


### PR DESCRIPTION
Found a couple of small bugs while reading the code:

**`print_top()` ignores the `n` parameter**

The `report` command passes `--limit` to `print_top(n=limit)`, but the function had hardcoded `[:10]` and `> 10` instead of `[:n]` and `> n`:

```python
# before
for event in sorted(events, ...)[:10]   # always 10
if len(events) > 10                      # always 10

# after
for event in sorted(events, ...)[:n]
if len(events) > n
```

**Unused `limit` in `get_eventcount()`**

`get_eventcount()` accepted a `limit` parameter but never passed it to the API. The server's count endpoint doesn't use it either, so it was dead code.