### PR TITLE
fix: escape_doublequote using JS regex syntax, never escapes anything

### DIFF
--- a/aw_client/queries.py
+++ b/aw_client/queries.py
@@ -250,7 +250,7 @@ def querystr_to_array(querystr: str) -> List[str]:
 
 
 def escape_doublequote(s: str) -> str:
-    return re.sub('/"/g', '\\"', s)
+    return s.replace('"', '\\"')
 
 
 def fullDesktopQuery(


### PR DESCRIPTION
`escape_doublequote` in `queries.py` was ported from `aw-webui/src/queries.ts` but the JavaScript regex literal `/"/g` got copied verbatim as a Python string `'"/g'`, which `re.sub` never matches. The function silently returns the input unchanged.

Switched to `str.replace()` — simpler and actually works.

Found by reading the code; the original TS version:
```ts
function escape_doublequote(s: string) {
  return s.replace(/"/g, '\"');
}
```