### PR TITLE
fix: browser query passes literal {default_limit} instead of 100

### DIFF
--- a/aw_client/queries.py
+++ b/aw_client/queries.py
@@ -274,7 +274,7 @@ def fullDesktopQuery(
 
     # Add browser-related query parts if browser buckets exist
     if params.bid_browsers:
-        query += """
+        query += f"""
         browser_events = split_url_events(browser_events);
         browser_urls = merge_events_by_keys(browser_events, ["url"]);
         browser_urls = sort_by_duration(browser_urls);


### PR DESCRIPTION
The browser query block in `fullDesktopQuery` uses a plain `"""` string, but `{default_limit}` only gets interpolated inside an f-string.

The base query block a few lines above already uses `f"""` correctly for the same variable — the browser block just missed the `f` prefix.

```python
# before (plain string — {default_limit} is literal text)
query += """
    browser_urls = limit_events(browser_urls, {default_limit});
"""

# after (f-string — resolves to 100)
query += f"""
    browser_urls = limit_events(browser_urls, {default_limit});
"""
```

One-character fix: add `f` to the string prefix.