### PR TITLE
feat: add --format json option to canonical command

### DIFF
--- a/aw_client/cli.py
+++ b/aw_client/cli.py
@@ -236,7 +236,12 @@ def print_top(events: List[Event], key=lambda e: e.data, title="Events", n=10):
 @click.option("--cache", is_flag=True)
 @click.option("--start", default=now - td1day, type=click.DateTime())
 @click.option("--stop", default=now + td1yr, type=click.DateTime())
-@click.option("--format", type=click.Choice(["table", "json"]), default="table", help="Output format (table or json)")
+@click.option(
+    "--format",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format (table or json)",
+)
 @click.pass_obj
 def canonical(
     obj: _Context,
@@ -279,7 +284,7 @@ def canonical(
             json_events = [
                 {
                     "timestamp": e.timestamp.isoformat(),
-                    "duration": e.duration,
+                    "duration": e.duration.total_seconds(),
                     "data": e.data,
                 }
                 for e in events

--- a/aw_client/cli.py
+++ b/aw_client/cli.py
@@ -236,6 +236,7 @@ def print_top(events: List[Event], key=lambda e: e.data, title="Events", n=10):
 @click.option("--cache", is_flag=True)
 @click.option("--start", default=now - td1day, type=click.DateTime())
 @click.option("--stop", default=now + td1yr, type=click.DateTime())
+@click.option("--format", type=click.Choice(["table", "json"]), default="table", help="Output format (table or json)")
 @click.pass_obj
 def canonical(
     obj: _Context,
@@ -243,6 +244,7 @@ def canonical(
     cache: bool,
     start: datetime,
     stop: datetime,
+    format: str,
     name: Optional[str] = None,
 ):
     logger.info(f"Querying between {start} and {stop}")
@@ -270,29 +272,43 @@ def canonical(
 
     # TODO: Print titles, apps, categories, with most time
     for period in result:
-        print()
         events = _parse_events(period)
-        print(f"Showing last 10 out of {len(events)} events:")
 
-        print(
-            tabulate(
-                [
-                    (
-                        str(e.timestamp).split(".")[0],
-                        str(e.duration).split(".")[0],
-                        f'[{e.data["app"]}] {textwrap.shorten(e.data["title"], 60, placeholder="...")}',
-                    )
-                    for e in events[-10:]
-                ],
-                headers=["Timestamp", "Duration", "Data"],
+        if format == "json":
+            # Output as JSON array with ISO-8601 timestamps
+            json_events = [
+                {
+                    "timestamp": e.timestamp.isoformat(),
+                    "duration": e.duration,
+                    "data": e.data,
+                }
+                for e in events
+            ]
+            print(json.dumps(json_events))
+        else:
+            # Table format (original behavior)
+            print()
+            print(f"Showing last 10 out of {len(events)} events:")
+
+            print(
+                tabulate(
+                    [
+                        (
+                            str(e.timestamp).split(".")[0],
+                            str(e.duration).split(".")[0],
+                            f'[{e.data["app"]}] {textwrap.shorten(e.data["title"], 60, placeholder="...")}',
+                        )
+                        for e in events[-10:]
+                    ],
+                    headers=["Timestamp", "Duration", "Data"],
+                )
             )
-        )
 
-        print()
-        print(
-            "Total duration:\t",
-            timedelta(seconds=sum(e["duration"] for e in period)),
-        )
+            print()
+            print(
+                "Total duration:\t",
+                timedelta(seconds=sum(e["duration"] for e in period)),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add JSON output support to the 'canonical' subcommand to enable machine-readable access to canonical events.

## Motivation

This addresses the ActivityWatch × AI agent enablement workflow, allowing AI agents to consume categorized activity data without reimplementing the canonical query. The feature was documented in the agent enablement docs but the CLI flag implementation was missing.

## Changes

- Add `--format` option to canonical command with choices: 'table' (default, preserving existing behavior) and 'json'
- JSON output emits an array of events with ISO-8601 formatted timestamps
- Each event includes: timestamp (ISO-8601), duration (seconds), and data object
- Preserves existing table output format and behavior

## Usage

```bash
# Human-readable table format (default)
aw-client canonical myhost

# Machine-readable JSON for AI agents
aw-client canonical myhost --format json | jq '.[] | {timestamp, data}'
```

## Testing

The change is backward compatible:
- Default behavior (table format) is unchanged
- No breaking changes to existing CLI
- JSON output follows the same event schema used by `aw-core` models